### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/TrackerZapper/AppDelegate.swift
+++ b/TrackerZapper/AppDelegate.swift
@@ -196,6 +196,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "ref",
             "s_kwcid",
             "sb_referer_host",
+            "scrolla",
             "soc_src",
             "soc_trk",
             "spm",


### PR DESCRIPTION
Propose stripping "?scrolla" parameter as it probably functions as a tracker. You can find it in use on, e.g., the Verge, Jalopnik, etc. Here's an example link: https://www.theverge.com/2021/10/5/22711837/mark-zuckerberg-responds-to-facebook-whistleblower?scrolla=5eb6d68b7fedc32c19ef33b4