### PR TITLE
Fix for NSStatus Item not working correctly

### DIFF
--- a/TrackerZapper/AppDelegate.swift
+++ b/TrackerZapper/AppDelegate.swift
@@ -60,7 +60,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         NotificationCenter.default.addObserver(self, selector: #selector(onPasteboardChanged), name: .NSPasteboardDidChange, object: nil)
         
-        statusBar = NSStatusBar.init()
+        statusBar = NSStatusBar.system
         statusItem = statusBar!.statusItem(withLength: 28.0)
         
         if let statusBarButton = statusItem!.button {


### PR DESCRIPTION
Hi, a status item shouldn't be created via NSStatusBar.init instead of NSStatusBar.system, using NSStatusBar.init it does not change screens correctly, and also prevents other menu bar item from ordering (via ⌘+dragging).
Using NSStatusBar.system is correct and prevents this.
The ultimate fix is for Apple to fix the bugs in using NSStatusBar.init but until this happens NSStatusBar.system should always be used.