### PR TITLE
Handling Twitter tracking parameters

### DIFF
--- a/TrackerZapper.xcodeproj/project.pbxproj
+++ b/TrackerZapper.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rknightuk.TrackerZapper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/TrackerZapper/AppDelegate.swift
+++ b/TrackerZapper/AppDelegate.swift
@@ -157,71 +157,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
         let matches = detector.matches(in: item, options: [], range: NSRange(location: 0, length: item.utf16.count))
 
-        // prefixes from various places including
-        // https://github.com/newhouse/url-tracking-stripper/blob/master/assets/js/trackers.js
-        var REMOVE = [
-            "_bta_c",
-            "_bta_tid",
-            "_ga",
-            "_hsenc",
-            "_hsmi",
-            "_ke",
-            "_openstat",
-            "cid",
-            "dm_i",
-            "ef_id",
-            "epik",
-            "fbclid",
-            "gclid",
-            "gclsrc",
-            "gdffi",
-            "gdfms",
-            "gdftrk",
-            "hsa_",
-            "igshid",
-            "matomo_",
-            "mc_",
-            "mkwid",
-            "msclkid",
-            "mtm_",
-            "ns_",
-            "oly_anon_id",
-            "oly_enc_id",
-            "otc",
-            "pcrid",
-            "piwik_",
-            "pk_",
-            "rb_clickid",
-            "redirect_log_mongo_id",
-            "redirect_mongo_id",
-            "ref",
-            "s_kwcid",
-            "sb_referer_host",
-            "scrolla",
-            "soc_src",
-            "soc_trk",
-            "spm",
-            "sr_",
-            "srcid",
-            "stm_",
-            "trk_",
-            "utm_",
-            "vero_",
-        ]
-        
-        // Prefixes for Twitter
-        let twitterParams = [
-            "s",
-            "t"
-        ]
-        
-        // Twitter uses extremely generic "s" and "t" params in its tracker links,
-        // so only adding them if it's a twitter link to not break other sites
-        if (item.contains("twitter.com"))
-        {
-            REMOVE.append(contentsOf: twitterParams)
-        }
-
         var formatted = item
 
         for match in matches {
@@ -231,8 +166,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if (urlParts.indices.contains(1))
             {
                 var params = urlParts[1].components(separatedBy: "&")
-                for r in REMOVE {
-                    params = params.filter { !$0.starts(with: r)}
+                for r in paramsToRemove {
+                    if (url.contains(r.website)) {
+                        params = params.filter { !$0.starts(with: r.parameterPrefix) }
+                    }
                 }
                 let joinedParams = params.joined(separator: "&")
                 

--- a/TrackerZapper/AppDelegate.swift
+++ b/TrackerZapper/AppDelegate.swift
@@ -159,7 +159,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // prefixes from various places including
         // https://github.com/newhouse/url-tracking-stripper/blob/master/assets/js/trackers.js
-        let REMOVE = [
+        var REMOVE = [
             "_bta_c",
             "_bta_tid",
             "_ga",
@@ -208,6 +208,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "utm_",
             "vero_",
         ]
+        
+        // Prefixes for Twitter
+        let twitterParams = [
+            "s",
+            "t"
+        ]
+        
+        // Twitter uses extremely generic "s" and "t" params in its tracker links,
+        // so only adding them if it's a twitter link to not break other sites
+        if (item.contains("twitter.com"))
+        {
+            REMOVE.append(contentsOf: twitterParams)
+        }
 
         var formatted = item
 

--- a/TrackerZapper/TrackerURLParameters.swift
+++ b/TrackerZapper/TrackerURLParameters.swift
@@ -1,0 +1,83 @@
+//
+//  TrackerURLParameters.swift
+//  TrackerZapper
+//
+//  Created by Arthur Lockman on 3/13/22.
+//
+
+import Foundation
+
+class TrackerParameter {
+    var website: String = ""
+    var parameterPrefix: String
+
+    init(parameterPrefix: String, website: String)
+    {
+        self.website = website
+        self.parameterPrefix = parameterPrefix
+    }
+
+    init(parameterPrefix: String)
+    {
+        self.website = ""
+        self.parameterPrefix = parameterPrefix
+    }
+}
+
+// prefixes from various places including
+// https://github.com/newhouse/url-tracking-stripper/blob/master/assets/js/trackers.js
+let paramsToRemove = [
+    TrackerParameter(parameterPrefix: "_bta_c"),
+    TrackerParameter(parameterPrefix: "_bta_tid"),
+    TrackerParameter(parameterPrefix: "_ga"),
+    TrackerParameter(parameterPrefix: "_hsenc"),
+    TrackerParameter(parameterPrefix: "_hsmi"),
+    TrackerParameter(parameterPrefix: "_ke"),
+    TrackerParameter(parameterPrefix: "_openstat"),
+    TrackerParameter(parameterPrefix: "cid"),
+    TrackerParameter(parameterPrefix: "dm_i"),
+    TrackerParameter(parameterPrefix: "ef_id"),
+    TrackerParameter(parameterPrefix: "epik"),
+    TrackerParameter(parameterPrefix: "fbclid"),
+    TrackerParameter(parameterPrefix: "gclid"),
+    TrackerParameter(parameterPrefix: "gclsrc"),
+    TrackerParameter(parameterPrefix: "gdffi"),
+    TrackerParameter(parameterPrefix: "gdfms"),
+    TrackerParameter(parameterPrefix: "gdftrk"),
+    TrackerParameter(parameterPrefix: "hsa_"),
+    TrackerParameter(parameterPrefix: "igshid"),
+    TrackerParameter(parameterPrefix: "matomo_"),
+    TrackerParameter(parameterPrefix: "mc_"),
+    TrackerParameter(parameterPrefix: "mkwid"),
+    TrackerParameter(parameterPrefix: "msclkid"),
+    TrackerParameter(parameterPrefix: "mtm_"),
+    TrackerParameter(parameterPrefix: "ns_"),
+    TrackerParameter(parameterPrefix: "oly_anon_id"),
+    TrackerParameter(parameterPrefix: "oly_enc_id"),
+    TrackerParameter(parameterPrefix: "otc"),
+    TrackerParameter(parameterPrefix: "pcrid"),
+    TrackerParameter(parameterPrefix: "piwik_"),
+    TrackerParameter(parameterPrefix: "pk_"),
+    TrackerParameter(parameterPrefix: "rb_clickid"),
+    TrackerParameter(parameterPrefix: "redirect_log_mongo_id"),
+    TrackerParameter(parameterPrefix: "redirect_mongo_id"),
+    TrackerParameter(parameterPrefix: "ref"),
+    TrackerParameter(parameterPrefix: "s_kwcid"),
+    TrackerParameter(parameterPrefix: "sb_referer_host"),
+    TrackerParameter(parameterPrefix: "scrolla"),
+    TrackerParameter(parameterPrefix: "soc_src"),
+    TrackerParameter(parameterPrefix: "soc_trk"),
+    TrackerParameter(parameterPrefix: "spm"),
+    TrackerParameter(parameterPrefix: "sr_"),
+    TrackerParameter(parameterPrefix: "srcid"),
+    TrackerParameter(parameterPrefix: "stm_"),
+    TrackerParameter(parameterPrefix: "trk_"),
+    TrackerParameter(parameterPrefix: "utm_"),
+    TrackerParameter(parameterPrefix: "vero_"),
+    TrackerParameter(parameterPrefix: "t", website: "twitter"),
+    TrackerParameter(parameterPrefix: "s", website: "twitter"),
+    TrackerParameter(parameterPrefix: "si", website: "spotify"),
+    TrackerParameter(parameterPrefix: "pd_", website: "amazon"),
+    TrackerParameter(parameterPrefix: "pf_", website: "amazon"),
+    TrackerParameter(parameterPrefix: "ref_", website: "amazon")
+]


### PR DESCRIPTION
https://github.com/rknightuk/TrackerZapper/issues/13

Twitter uses really generic "s" and "t" parameters. They're really annoying.
I've used a naïve way to remove them that doesn't break other sites that
use those parameters for other things. The app should only remove them
if the URL is a twitter link, otherwise leave them alone.